### PR TITLE
Add support for output file suffixes (versions, for example)

### DIFF
--- a/src/it/filename-suffix/invoker.properties
+++ b/src/it/filename-suffix/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean compile

--- a/src/it/filename-suffix/pom.xml
+++ b/src/it/filename-suffix/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.lesscss.it</groupId>
+    <artifactId>filena-emsuffix</artifactId>
+    <version>testing</version>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.lesscss</groupId>
+                <artifactId>lesscss-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                  <outputFileSuffix>-1.33.7</outputFileSuffix>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+</project>

--- a/src/it/filename-suffix/src/main/less/test.less
+++ b/src/it/filename-suffix/src/main/less/test.less
@@ -1,0 +1,8 @@
+@color: #4d926f;
+
+#header {
+  color: @color;
+}
+h2 {
+  color: @color;
+}

--- a/src/it/filename-suffix/verify.groovy
+++ b/src/it/filename-suffix/verify.groovy
@@ -1,0 +1,11 @@
+expected = """#header {
+  color: #4d926f;
+}
+h2 {
+  color: #4d926f;
+}
+"""
+
+css = new File(basedir, "target/test-1.33.7.css")
+assert css.exists()
+assert css.getText().equals(expected)

--- a/src/main/java/org/lesscss/mojo/CompileMojo.java
+++ b/src/main/java/org/lesscss/mojo/CompileMojo.java
@@ -44,6 +44,13 @@ public class CompileMojo extends AbstractLessCssMojo {
 	private File outputDirectory;
 
 	/**
+	 * An optional suffix to append to each output filename, before the .less extension
+	 *
+	 * @parameter expression="${lesscss.outputFileSuffix}"
+	 */
+	private String outputFileSuffix = "";
+
+	/**
 	 * When <code>true</code> the LESS compiler will compress the CSS stylesheets.
 	 * 
 	 * @parameter expression="${lesscss.compress}" default-value="false"
@@ -84,6 +91,7 @@ public class CompileMojo extends AbstractLessCssMojo {
 		if (getLog().isDebugEnabled()) {
 			getLog().debug("sourceDirectory = " + sourceDirectory);
 			getLog().debug("outputDirectory = " + outputDirectory);
+			getLog().debug("outputFileSuffix = " + outputFileSuffix);
 			getLog().debug("includes = " + Arrays.toString(includes));
 			getLog().debug("excludes = " + Arrays.toString(excludes));
 			getLog().debug("force = " + force);
@@ -117,7 +125,10 @@ public class CompileMojo extends AbstractLessCssMojo {
 
 				buildContext.removeMessages(input);
 
-				File output = new File(outputDirectory, file.replace(".less", ".css"));
+				String filename = file.replace(".less", "%s.css");
+				filename = String.format(filename, outputFileSuffix);
+
+				File output = new File(outputDirectory, filename);
 
 				if (!output.getParentFile().exists() && !output.getParentFile().mkdirs()) {
 					throw new MojoExecutionException("Cannot create output directory " + output.getParentFile());


### PR DESCRIPTION
In our project, we are required to deliver our project files (.css, .js, etc) with a version number, i.e. project-1.33.7.css. At the moment, the lesscss-maven-plugin does not seem to support that, and can only customize the folder to output the files to.

This (small) commit adds support to add a common (optional) suffix to output files, for example:

```
<configuration>
    <outputFileSuffix>-${project.version}</outputFileSuffix>
```

   </configuration>

This will output all input files as <original-filename>-1.33.7-SNAPSHOT.css, for example.

I've added a unit test and an integration test for this parameter, although the unit test itself isn't very pretty (lot of copy / paste). But, it was that or refactor the entire suite, don't think that'd help.

It would be nice if this could be integrated into an official release, atm we're getting by with a local repository installation.
