### PR TITLE
bug fix with absolute uri IMPORT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.lesscss</groupId>
             <artifactId>lesscss</artifactId>
-            <version>1.3.3</version>
+            <version>1.5.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -90,7 +90,7 @@
                     <target>1.5</target>
                 </configuration>
             </plugin>
-            <plugin>
+            <!-- plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>1.5</version>
@@ -111,7 +111,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin-->
         </plugins>
     </build>
     

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                     <target>1.5</target>
                 </configuration>
             </plugin>
-            <!-- plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>1.5</version>
@@ -111,7 +111,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin-->
+            </plugin>
         </plugins>
     </build>
     

--- a/src/main/java/org/lesscss/mojo/CompileMojo.java
+++ b/src/main/java/org/lesscss/mojo/CompileMojo.java
@@ -77,7 +77,7 @@ public class CompileMojo extends AbstractLessCssMojo {
    * 
    * @parameter
    */
-  private String nodeExecutable;
+  private File nodeExecutable;
 
   /**
    * Execute the MOJO.
@@ -162,7 +162,7 @@ public class CompileMojo extends AbstractLessCssMojo {
     if (nodeExecutable != null) {
       NodeJsLessCompiler lessCompiler;
       try {
-        lessCompiler = new NodeJsLessCompiler(compress, encoding, getLog());
+        lessCompiler = new NodeJsLessCompiler(nodeExecutable, compress, encoding, getLog());
       } catch (IOException e) {
         throw new MojoExecutionException(e.getMessage(), e);
       }

--- a/src/main/java/org/lesscss/mojo/CompileMojo.java
+++ b/src/main/java/org/lesscss/mojo/CompileMojo.java
@@ -35,156 +35,153 @@ import org.sonatype.plexus.build.incremental.BuildContext;
  */
 public class CompileMojo extends AbstractLessCssMojo {
 
-	/**
-	 * The directory for compiled CSS stylesheets.
-	 * 
-	 * @parameter expression="${lesscss.outputDirectory}" default-value="${project.build.directory}"
-	 * @required
-	 */
-	private File outputDirectory;
+  /**
+   * The directory for compiled CSS stylesheets.
+   * 
+   * @parameter expression="${lesscss.outputDirectory}" default-value="${project.build.directory}"
+   * @required
+   */
+  private File outputDirectory;
 
-	/**
-	 * When <code>true</code> the LESS compiler will compress the CSS stylesheets.
-	 * 
-	 * @parameter expression="${lesscss.compress}" default-value="false"
-	 */
-	private boolean compress;
+  /**
+   * When <code>true</code> the LESS compiler will compress the CSS stylesheets.
+   * 
+   * @parameter expression="${lesscss.compress}" default-value="false"
+   */
+  private boolean compress;
 
-	/**
-	 * The character encoding the LESS compiler will use for writing the CSS stylesheets.
-	 * 
-	 * @parameter expression="${lesscss.encoding}" default-value="${project.build.sourceEncoding}"
-	 */
-	private String encoding;
+  /**
+   * The character encoding the LESS compiler will use for writing the CSS stylesheets.
+   * 
+   * @parameter expression="${lesscss.encoding}" default-value="${project.build.sourceEncoding}"
+   */
+  private String encoding;
 
-	/**
-	 * When <code>true</code> forces the LESS compiler to always compile the LESS sources. By default LESS sources are only compiled when modified (including imports) or the CSS stylesheet does not exists.
-	 * 
-	 * @parameter expression="${lesscss.force}" default-value="false"
-	 */
-	private boolean force;
+  /**
+   * When <code>true</code> forces the LESS compiler to always compile the LESS sources. By default LESS sources are
+   * only compiled when modified (including imports) or the CSS stylesheet does not exists.
+   * 
+   * @parameter expression="${lesscss.force}" default-value="false"
+   */
+  private boolean force;
 
-	/**
-	 * The location of the LESS JavasSript file.
-	 * 
-	 * @parameter
-	 */
-	private File lessJs;
+  /**
+   * The location of the LESS JavasSript file.
+   * 
+   * @parameter
+   */
+  private File lessJs;
 
-	/**
-	 * The location of the NodeJS executable.
-	 *
-	 * @parameter
-	 */
-	private String nodeExecutable;
+  /**
+   * The location of the NodeJS executable.
+   * 
+   * @parameter
+   */
+  private String nodeExecutable;
 
-	/**
-	 * Execute the MOJO.
-	 * 
-	 * @throws MojoExecutionException
-	 *             if something unexpected occurs.
-	 */
-	public void execute() throws MojoExecutionException {
+  /**
+   * Execute the MOJO.
+   * 
+   * @throws MojoExecutionException if something unexpected occurs.
+   */
+  public void execute() throws MojoExecutionException {
 
-		long start = System.currentTimeMillis();
+    long start = System.currentTimeMillis();
 
-		if (getLog().isDebugEnabled()) {
-			getLog().debug("sourceDirectory = " + sourceDirectory);
-			getLog().debug("outputDirectory = " + outputDirectory);
-			getLog().debug("includes = " + Arrays.toString(includes));
-			getLog().debug("excludes = " + Arrays.toString(excludes));
-			getLog().debug("force = " + force);
-			getLog().debug("lessJs = " + lessJs);
-		}
+    if (getLog().isDebugEnabled()) {
+      getLog().debug("sourceDirectory = " + sourceDirectory);
+      getLog().debug("outputDirectory = " + outputDirectory);
+      getLog().debug("includes = " + Arrays.toString(includes));
+      getLog().debug("excludes = " + Arrays.toString(excludes));
+      getLog().debug("force = " + force);
+      getLog().debug("lessJs = " + lessJs);
+    }
 
-		String[] files = getIncludedFiles();
+    String[] files = getIncludedFiles();
 
-		if (files == null || files.length < 1) {
-			getLog().info("Nothing to compile - no LESS sources found");
-		} else {
-			if (getLog().isDebugEnabled()) {
-				getLog().debug("included files = " + Arrays.toString(files));
-			}
+    if (files == null || files.length < 1) {
+      getLog().info("Nothing to compile - no LESS sources found");
+    } else {
+      if (getLog().isDebugEnabled()) {
+        getLog().debug("included files = " + Arrays.toString(files));
+      }
 
-			Object lessCompiler = initLessCompiler();
-			try {
-				for (String file : files) {
-					File input = new File(sourceDirectory, file);
-	
-					buildContext.removeMessages(input);
-	
-					File output = new File(outputDirectory, file.replace(".less", ".css"));
-	
-					if (!output.getParentFile().exists() && !output.getParentFile().mkdirs()) {
-						throw new MojoExecutionException("Cannot create output directory " + output.getParentFile());
-					}
-	
-					try {
-						LessSource lessSource = new LessSource(input);
-	
-						if (output.lastModified() < lessSource.getLastModifiedIncludingImports() || force) {
-							getLog().info("Compiling LESS source: " + file + "...");
-							if (lessCompiler instanceof LessCompiler) {
-								((LessCompiler) lessCompiler).compile(lessSource, output, force);
-							} else {
-								((NodeJsLessCompiler) lessCompiler).compile(lessSource, output, force);
-							}
-							buildContext.refresh(output);
-						}
-						else {
-							getLog().info("Bypassing LESS source: " + file + " (not modified)");
-						}
-					} catch (IOException e) {
-						buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
-						throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
-					} catch (LessException e) {
-						String message = e.getMessage();
-						if (StringUtils.isEmpty(message)) {
-							message = "Error compiling LESS source";
-						}
-						buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
-						throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
-					} catch (InterruptedException e) {
-						buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
-						throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
-					}
-				}
-			} finally {
-				if (lessCompiler instanceof NodeJsLessCompiler) {
-					((NodeJsLessCompiler) lessCompiler).close();
-				}
-			}
+      Object lessCompiler = initLessCompiler();
+      try {
+        for (String file : files) {
+          File input = new File(sourceDirectory, file);
 
-			getLog().info("Compilation finished in " + (System.currentTimeMillis() - start) + " ms");
-		}
-	}
+          buildContext.removeMessages(input);
 
-	private Object initLessCompiler() throws MojoExecutionException {
-		if (nodeExecutable != null) {
-			NodeJsLessCompiler lessCompiler;
-			try {
-				lessCompiler = new NodeJsLessCompiler(compress, encoding, getLog());
-			} catch (IOException e) {
-				throw new MojoExecutionException(e.getMessage(), e);
-			}
-			if (lessJs != null) {
-				throw new MojoExecutionException(
-						"Custom LESS JavaScript is not currently supported when using nodeExecutable");
-			}
-			return lessCompiler;
-		} else {
-			LessCompiler lessCompiler = new LessCompiler();
-			lessCompiler.setCompress(compress);
-			lessCompiler.setEncoding(encoding);
-			if (lessJs != null) {
-				try {
-					lessCompiler.setLessJs(lessJs.toURI().toURL());
-				} catch (MalformedURLException e) {
-					throw new MojoExecutionException(
-							"Error while loading LESS JavaScript: " + lessJs.getAbsolutePath(), e);
-				}
-			}
-			return lessCompiler;
-		}
-	}
+          File output = new File(outputDirectory, file.replace(".less", ".css"));
+
+          if (!output.getParentFile().exists() && !output.getParentFile().mkdirs()) {
+            throw new MojoExecutionException("Cannot create output directory " + output.getParentFile());
+          }
+
+          try {
+            LessSource lessSource = new LessSource(sourceDirectory, input);
+
+            if (output.lastModified() < lessSource.getLastModifiedIncludingImports() || force) {
+              getLog().info("Compiling LESS source: " + file + "...");
+              if (lessCompiler instanceof LessCompiler) {
+                ((LessCompiler) lessCompiler).compile(lessSource, output, force);
+              } else {
+                ((NodeJsLessCompiler) lessCompiler).compile(lessSource, output, force);
+              }
+              buildContext.refresh(output);
+            } else {
+              getLog().info("Bypassing LESS source: " + file + " (not modified)");
+            }
+          } catch (IOException e) {
+            buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
+            throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
+          } catch (LessException e) {
+            String message = e.getMessage();
+            if (StringUtils.isEmpty(message)) {
+              message = "Error compiling LESS source";
+            }
+            buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
+            throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
+          } catch (InterruptedException e) {
+            buildContext.addMessage(input, 0, 0, "Error compiling LESS source", BuildContext.SEVERITY_ERROR, e);
+            throw new MojoExecutionException("Error while compiling LESS source: " + file, e);
+          }
+        }
+      } finally {
+        if (lessCompiler instanceof NodeJsLessCompiler) {
+          ((NodeJsLessCompiler) lessCompiler).close();
+        }
+      }
+
+      getLog().info("Compilation finished in " + (System.currentTimeMillis() - start) + " ms");
+    }
+  }
+
+  private Object initLessCompiler() throws MojoExecutionException {
+    if (nodeExecutable != null) {
+      NodeJsLessCompiler lessCompiler;
+      try {
+        lessCompiler = new NodeJsLessCompiler(compress, encoding, getLog());
+      } catch (IOException e) {
+        throw new MojoExecutionException(e.getMessage(), e);
+      }
+      if (lessJs != null) {
+        throw new MojoExecutionException("Custom LESS JavaScript is not currently supported when using nodeExecutable");
+      }
+      return lessCompiler;
+    } else {
+      LessCompiler lessCompiler = new LessCompiler();
+      lessCompiler.setCompress(compress);
+      lessCompiler.setEncoding(encoding);
+      if (lessJs != null) {
+        try {
+          lessCompiler.setLessJs(lessJs.toURI().toURL());
+        } catch (MalformedURLException e) {
+          throw new MojoExecutionException("Error while loading LESS JavaScript: " + lessJs.getAbsolutePath(), e);
+        }
+      }
+      return lessCompiler;
+    }
+  }
 }

--- a/src/main/java/org/lesscss/mojo/NodeJsLessCompiler.java
+++ b/src/main/java/org/lesscss/mojo/NodeJsLessCompiler.java
@@ -72,8 +72,10 @@ public class NodeJsLessCompiler {
 	private final boolean compress;
 	private final String encoding;
 	private final File tempDir;
-
-	public NodeJsLessCompiler(boolean compress, String encoding, Log log) throws IOException {
+	private final File nodeExecutable;
+	
+	public NodeJsLessCompiler(File nodeExecutable, boolean compress, String encoding, Log log) throws IOException {
+		this.nodeExecutable = nodeExecutable;
 		this.compress = compress;
 		this.encoding = encoding;
 		this.log = log;
@@ -128,7 +130,7 @@ public class NodeJsLessCompiler {
 		File outputFile = File.createTempFile("lessc-output-", ".css");
 		File lesscJsFile = new File(tempDir, "lessc.js");
 
-		ProcessBuilder pb = new ProcessBuilder("node", lesscJsFile.getAbsolutePath(),
+		ProcessBuilder pb = new ProcessBuilder(nodeExecutable.getAbsolutePath(), lesscJsFile.getAbsolutePath(),
 				inputFile.getAbsolutePath(), outputFile.getAbsolutePath(), String.valueOf(compress));
 		pb.redirectErrorStream(true);
 		Process process = pb.start();

--- a/src/test/java/org/lesscss/mojo/CompileMojoTest.java
+++ b/src/test/java/org/lesscss/mojo/CompileMojoTest.java
@@ -42,7 +42,6 @@ import org.junit.runner.RunWith;
 import org.lesscss.LessCompiler;
 import org.lesscss.LessException;
 import org.lesscss.LessSource;
-import org.lesscss.mojo.CompileMojo;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -52,428 +51,430 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 @RunWith(PowerMockRunner.class)
 public class CompileMojoTest extends AbstractMojoTestCase {
 
-	private CompileMojo mojo;
+  private CompileMojo mojo;
 
-	private File sourceDirectory = new File("./source");
+  private final File sourceDirectory = new File("./source");
 
-	private File outputDirectory = new File("./output");
+  private final File outputDirectory = new File("./output");
 
-	private String[] includes = new String[] { "include" };
+  private final String[] includes = new String[]{"include"};
 
-	private String[] excludes = new String[] { "exclude" };
+  private final String[] excludes = new String[]{"exclude"};
 
-	private String[] files = new String[] { "file" };
+  private String[] files = new String[]{"file"};
 
-	@Mock
-	private Log log;
+  @Mock
+  private Log log;
 
-	@Mock
-	private BuildContext buildContext;
+  @Mock
+  private BuildContext buildContext;
 
-	@Mock
-	private Scanner scanner;
+  @Mock
+  private Scanner scanner;
 
-	@Mock
-	private LessCompiler lessCompiler;
+  @Mock
+  private LessCompiler lessCompiler;
 
-	@Mock
-	private File lessJs;
+  @Mock
+  private File lessJs;
 
-	@Mock
-	private URI lessJsURI;
+  @Mock
+  private URI lessJsURI;
 
-	@Mock
-	private URL lessJsURL;
+  @Mock
+  private URL lessJsURL;
 
-	@Mock
-	private File input;
+  @Mock
+  private File input;
 
-	@Mock
-	private File output;
+  @Mock
+  private File output;
 
-	@Mock
-	private File parent;
+  @Mock
+  private File parent;
 
-	@Mock
-	private LessSource lessSource;
+  @Mock
+  private LessSource lessSource;
 
-	@Before
-	public void setUp() throws URISyntaxException, IllegalAccessException, IOException {
-		mojo = new CompileMojo();
-		mojo.setLog(log);
+  @Override
+  @Before
+  public void setUp() throws URISyntaxException, IllegalAccessException, IOException {
+    mojo = new CompileMojo();
+    mojo.setLog(log);
 
-		setVariableValueToObject(mojo, "buildContext", buildContext);
-		setVariableValueToObject(mojo, "sourceDirectory", sourceDirectory);
-		setVariableValueToObject(mojo, "outputDirectory", outputDirectory);
-		setVariableValueToObject(mojo, "includes", includes);
-		setVariableValueToObject(mojo, "excludes", excludes);
-	}
+    setVariableValueToObject(mojo, "buildContext", buildContext);
+    setVariableValueToObject(mojo, "sourceDirectory", sourceDirectory);
+    setVariableValueToObject(mojo, "outputDirectory", outputDirectory);
+    setVariableValueToObject(mojo, "includes", includes);
+    setVariableValueToObject(mojo, "excludes", excludes);
+  }
 
-	@Test
-	public void testExecution() throws Exception {
-		files = new String[] { "less.less" };
+  @Test
+  public void testExecution() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenReturn(lessSource);
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenReturn(lessSource);
 
-		when(output.lastModified()).thenReturn(1l);
-		when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
+    when(output.lastModified()).thenReturn(1l);
+    when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output).getParentFile();
-		verify(parent).exists();
+    verify(output).getParentFile();
+    verify(parent).exists();
 
-		verifyNew(LessSource.class).withArguments(input);
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
 
-		verify(output).lastModified();
-		verify(lessSource).getLastModifiedIncludingImports();
+    verify(output).lastModified();
+    verify(lessSource).getLastModifiedIncludingImports();
 
-		verify(log).info("Compiling LESS source: less.less...");
-		verify(lessCompiler).compile(lessSource, output, false);
-	}
+    verify(log).info("Compiling LESS source: less.less...");
+    verify(lessCompiler).compile(lessSource, output, false);
+  }
 
-	@Test
-	public void testExecutionNotModified() throws Exception {
-		files = new String[] { "less.less" };
+  @Test
+  public void testExecutionNotModified() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenReturn(lessSource);
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenReturn(lessSource);
 
-		when(output.lastModified()).thenReturn(2l);
-		when(lessSource.getLastModifiedIncludingImports()).thenReturn(1l);
+    when(output.lastModified()).thenReturn(2l);
+    when(lessSource.getLastModifiedIncludingImports()).thenReturn(1l);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output).getParentFile();
-		verify(parent).exists();
+    verify(output).getParentFile();
+    verify(parent).exists();
 
-		verifyNew(LessSource.class).withArguments(input);
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verify(output).lastModified();
-		verify(lessSource).getLastModifiedIncludingImports();
+    verify(output).lastModified();
+    verify(lessSource).getLastModifiedIncludingImports();
 
-		verify(log).info("Bypassing LESS source: less.less (not modified)");
-		verifyNoMoreInteractions(lessCompiler);
-	}
+    verify(log).info("Bypassing LESS source: less.less (not modified)");
+    verifyNoMoreInteractions(lessCompiler);
+  }
 
-	@Test
-	public void testExecutionIncludedFilesEmpty() throws Exception {
-		files = new String[] {};
+  @Test
+  public void testExecutionIncludedFilesEmpty() throws Exception {
+    files = new String[]{};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(log).info("Nothing to compile - no LESS sources found");
-	}
+    verify(log).info("Nothing to compile - no LESS sources found");
+  }
 
-	@Test
-	public void testExecutionIncludedFilesNull() throws Exception {
-		files = null;
+  @Test
+  public void testExecutionIncludedFilesNull() throws Exception {
+    files = null;
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(log).info("Nothing to compile - no LESS sources found");
-	}
+    verify(log).info("Nothing to compile - no LESS sources found");
+  }
 
-	@Test(expected = MojoExecutionException.class)
-	public void testExecutionIOExceptionWhenCreatingLessSource() throws Exception {
-		files = new String[] { "less.less" };
+  @Test(expected = MojoExecutionException.class)
+  public void testExecutionIOExceptionWhenCreatingLessSource() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenThrow(new IOException());
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenThrow(new IOException());
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output).getParentFile();
-		verify(parent).exists();
+    verify(output).getParentFile();
+    verify(parent).exists();
 
-		verifyNew(LessSource.class).withArguments(input);
-	}
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
+  }
 
-	@Test(expected = MojoExecutionException.class)
-	public void testExecutionLessExceptionWhenCompilingLessSource() throws Exception {
-		files = new String[] { "less.less" };
+  @Test(expected = MojoExecutionException.class)
+  public void testExecutionLessExceptionWhenCompilingLessSource() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenReturn(lessSource);
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenReturn(lessSource);
 
-		when(output.lastModified()).thenReturn(1l);
-		when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
+    when(output.lastModified()).thenReturn(1l);
+    when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
 
-		doThrow(new LessException(new Throwable())).when(lessCompiler).compile(lessSource, output, false);
+    doThrow(new LessException(new Throwable())).when(lessCompiler).compile(lessSource, output, false);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output).getParentFile();
-		verify(parent).exists();
+    verify(output).getParentFile();
+    verify(parent).exists();
 
-		verifyNew(LessSource.class).withArguments(input);
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
 
-		verify(output).lastModified();
-		verify(lessSource).getLastModifiedIncludingImports();
+    verify(output).lastModified();
+    verify(lessSource).getLastModifiedIncludingImports();
 
-		verify(log).info("Compiling LESS source: less.less...");
-		verify(lessCompiler).compile(lessSource, output, false);
-	}
+    verify(log).info("Compiling LESS source: less.less...");
+    verify(lessCompiler).compile(lessSource, output, false);
+  }
 
-	@Test
-	public void testExecutionWithCustomLessJs() throws Exception {
-		setVariableValueToObject(mojo, "lessJs", lessJs);
+  @Test
+  public void testExecutionWithCustomLessJs() throws Exception {
+    setVariableValueToObject(mojo, "lessJs", lessJs);
 
-		files = new String[] { "less.less" };
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		when(lessJs.toURI()).thenReturn(lessJsURI);
-		when(lessJsURI.toURL()).thenReturn(lessJsURL);
+    when(lessJs.toURI()).thenReturn(lessJsURI);
+    when(lessJsURI.toURL()).thenReturn(lessJsURL);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenReturn(lessSource);
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenReturn(lessSource);
 
-		when(output.lastModified()).thenReturn(1l);
-		when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
+    when(output.lastModified()).thenReturn(1l);
+    when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
-		verify(lessCompiler).setLessJs(lessJsURL);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
+    verify(lessCompiler).setLessJs(lessJsURL);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output).getParentFile();
-		verify(parent).exists();
+    verify(output).getParentFile();
+    verify(parent).exists();
 
-		verifyNew(LessSource.class).withArguments(input);
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
 
-		verify(output).lastModified();
-		verify(lessSource).getLastModifiedIncludingImports();
+    verify(output).lastModified();
+    verify(lessSource).getLastModifiedIncludingImports();
 
-		verify(log).info("Compiling LESS source: less.less...");
-		verify(lessCompiler).compile(lessSource, output, false);
-	}
+    verify(log).info("Compiling LESS source: less.less...");
+    verify(lessCompiler).compile(lessSource, output, false);
+  }
 
-	@Test(expected = MojoExecutionException.class)
-	public void testExecutionMalformedURLExceptionWhenCustomLessJs() throws Exception {
-		setVariableValueToObject(mojo, "lessJs", lessJs);
+  @Test(expected = MojoExecutionException.class)
+  public void testExecutionMalformedURLExceptionWhenCustomLessJs() throws Exception {
+    setVariableValueToObject(mojo, "lessJs", lessJs);
 
-		files = new String[] { "less.less" };
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		when(lessJs.toURI()).thenReturn(lessJsURI);
-		when(lessJsURI.toURL()).thenThrow(new MalformedURLException());
+    when(lessJs.toURI()).thenReturn(lessJsURI);
+    when(lessJsURI.toURL()).thenThrow(new MalformedURLException());
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
-	}
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
+  }
 
-	@Test
-	public void testExecutionMakeDirsWhenOutputDirectoryDoesNotExists() throws Exception {
-		files = new String[] { "less.less" };
+  @Test
+  public void testExecutionMakeDirsWhenOutputDirectoryDoesNotExists() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(false);
-		when(parent.mkdirs()).thenReturn(true);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(false);
+    when(parent.mkdirs()).thenReturn(true);
 
-		whenNew(LessSource.class).withArguments(input).thenReturn(lessSource);
+    whenNew(LessSource.class).withArguments(sourceDirectory, input).thenReturn(lessSource);
 
-		when(output.lastModified()).thenReturn(1l);
-		when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
+    when(output.lastModified()).thenReturn(1l);
+    when(lessSource.getLastModifiedIncludingImports()).thenReturn(2l);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output, times(2)).getParentFile();
-		verify(parent).exists();
-		verify(parent).mkdirs();
+    verify(output, times(2)).getParentFile();
+    verify(parent).exists();
+    verify(parent).mkdirs();
 
-		verifyNew(LessSource.class).withArguments(input);
+    verifyNew(LessSource.class).withArguments(sourceDirectory, input);
 
-		verify(output).lastModified();
-		verify(lessSource).getLastModifiedIncludingImports();
+    verify(output).lastModified();
+    verify(lessSource).getLastModifiedIncludingImports();
 
-		verify(log).info("Compiling LESS source: less.less...");
-		verify(lessCompiler).compile(lessSource, output, false);
-	}
+    verify(log).info("Compiling LESS source: less.less...");
+    verify(lessCompiler).compile(lessSource, output, false);
+  }
 
-	@Test(expected = MojoExecutionException.class)
-	public void testExecutionMakeDirsFailsWhenOutputDirectoryDoesNotExists() throws Exception {
-		files = new String[] { "less.less" };
+  @Test(expected = MojoExecutionException.class)
+  public void testExecutionMakeDirsFailsWhenOutputDirectoryDoesNotExists() throws Exception {
+    files = new String[]{"less.less"};
 
-		when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
-		when(scanner.getIncludedFiles()).thenReturn(files);
+    when(buildContext.newScanner(sourceDirectory, true)).thenReturn(scanner);
+    when(scanner.getIncludedFiles()).thenReturn(files);
 
-		whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
+    whenNew(LessCompiler.class).withNoArguments().thenReturn(lessCompiler);
 
-		whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
-		whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
+    whenNew(File.class).withArguments(sourceDirectory, "less.less").thenReturn(input);
+    whenNew(File.class).withArguments(outputDirectory, "less.css").thenReturn(output);
 
-		when(output.getParentFile()).thenReturn(parent);
-		when(parent.exists()).thenReturn(false);
-		when(parent.mkdirs()).thenReturn(false);
+    when(output.getParentFile()).thenReturn(parent);
+    when(parent.exists()).thenReturn(false);
+    when(parent.mkdirs()).thenReturn(false);
 
-		mojo.execute();
+    mojo.execute();
 
-		verify(buildContext).newScanner(same(sourceDirectory), eq(true));
-		verify(scanner).setIncludes(same(includes));
-		verify(scanner).setExcludes(same(excludes));
-		verify(scanner).scan();
+    verify(buildContext).newScanner(same(sourceDirectory), eq(true));
+    verify(scanner).setIncludes(same(includes));
+    verify(scanner).setExcludes(same(excludes));
+    verify(scanner).scan();
 
-		verifyNew(LessCompiler.class).withNoArguments();
-		verify(lessCompiler).setCompress(false);
-		verify(lessCompiler).setEncoding(null);
+    verifyNew(LessCompiler.class).withNoArguments();
+    verify(lessCompiler).setCompress(false);
+    verify(lessCompiler).setEncoding(null);
 
-		verifyNew(File.class).withArguments(sourceDirectory, "less.less");
-		verifyNew(File.class).withArguments(outputDirectory, "less.css");
+    verifyNew(File.class).withArguments(sourceDirectory, "less.less");
+    verifyNew(File.class).withArguments(outputDirectory, "less.css");
 
-		verify(output, times(2)).getParentFile();
-		verify(parent).exists();
-		verify(parent).mkdirs();
-	}
+    verify(output, times(2)).getParentFile();
+    verify(parent).exists();
+    verify(parent).mkdirs();
+  }
 
-	@After
-	public void tearDown() {
-	}
+  @Override
+  @After
+  public void tearDown() {
+  }
 }


### PR DESCRIPTION
exemple :
@import "/bootstrap/less/bootstrap.less";

if the source file is not present into root directory.

the compilation fail :

[ERROR] D:\dev\billetel\IRIS_14.03\modules\lotus\src\main\webapp\bordel\less\sty
les.less [0:0]: Error compiling LESS source
java.io.FileNotFoundException: File D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\less\bootstrap\less\bootstrap.less not found.
        at org.lesscss.LessSource.<init>(LessSource.java:59)
        at org.lesscss.LessSource.resolveImports(LessSource.java:145)
        at org.lesscss.LessSource.<init>(LessSource.java:63)
        at org.lesscss.mojo.CompileMojo.execute(CompileMojo.java:123)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(Default
BuildPluginManager.java:106)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor
.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor
.java:153)

the file "bootstrap.less" is not in "D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\less\bootstrap\less\bootstrap.less" but into D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\bootstrap\less\bootstrap.less"
