### PR TITLE
Simple explicit watch mojo implementation

### DIFF
--- a/src/main/java/org/lesscss/mojo/WatchMojo.java
+++ b/src/main/java/org/lesscss/mojo/WatchMojo.java
@@ -1,0 +1,18 @@
+package org.lesscss.mojo;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Goal which compiles the LESS sources to CSS stylesheets.
+ *
+ * @author Marcel Overdijk
+ * @goal watch
+ */
+public class WatchMojo extends CompileMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        watch = true;
+        super.execute();
+    }
+}

--- a/src/main/java/org/lesscss/mojo/WatchMojo.java
+++ b/src/main/java/org/lesscss/mojo/WatchMojo.java
@@ -3,7 +3,7 @@ package org.lesscss.mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Goal which compiles the LESS sources to CSS stylesheets.
+ * Goal which will watch for changes in LESS files and compile if it detects one.
  *
  * @author Marcel Overdijk
  * @goal watch


### PR DESCRIPTION
Having an explicit watch mojo will make it easier to start the plugin from within IDE's like Intellij IDEA.
