### PR TITLE
- Use defaults for maven-compiler-plugin encoding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <encoding>UTF-8</encoding>
                     <source>1.5</source>
                     <target>1.5</target>
                 </configuration>


### PR DESCRIPTION
  No need to explicit configure the encoding.
